### PR TITLE
Feat: support redis cluster

### DIFF
--- a/lua/reentrantLock.lua
+++ b/lua/reentrantLock.lua
@@ -1,4 +1,4 @@
-local lock_key = KEYS[1]
+local lock_key = '{' .. KEYS[1] .. '}'
 local lock_value = ARGV[1]
 local lock_ttl = tonumber(ARGV[2])
 local reentrant_key = lock_key .. ':count:' .. lock_value

--- a/lua/reentrantRenew.lua
+++ b/lua/reentrantRenew.lua
@@ -1,4 +1,4 @@
-local lock_key = KEYS[1]
+local lock_key = '{' .. KEYS[1] .. '}'
 local lock_value = ARGV[1]
 local lock_ttl = tonumber(ARGV[2])
 local reentrant_key = lock_key .. ':count:' .. lock_value

--- a/lua/reentrantUnLock.lua
+++ b/lua/reentrantUnLock.lua
@@ -1,4 +1,4 @@
-local lock_key = KEYS[1]
+local lock_key = '{' .. KEYS[1] .. '}'
 local lock_value = ARGV[1]
 local reentrant_key = lock_key .. ':count:' .. lock_value
 local reentrant_count = tonumber(redis.call('GET', reentrant_key) or '0')


### PR DESCRIPTION
fix #43  ERR Script attempted to access a non local key in a cluster node script

Alter lua scripts, adding braces to lock_key to make sure the lock_key and reentrant_key exist in same cluster hash slot